### PR TITLE
Rename project to alternate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Polygot
+# Alternate
 
 A library to serve your Phoenix app in different locales.
 
@@ -6,18 +6,18 @@ A library to serve your Phoenix app in different locales.
 
 The package can be installed as:
 
-Add `polygot` to your list of dependencies in `mix.exs`:
+Add `alternate` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:polygot, "~> 0.2.0"}]
+  [{:alternate, "~> 0.2.0"}]
 end
 ```
 
-Ensure `polygot` is configured in `config/config.exs`:
+Ensure `alternate` is configured in `config/config.exs`:
 
 ```elixir
-config :polygot,
+config :alternate,
     locales: %{
         "en-GB" => %{ path_prefix: "gb" },
         "en-US" => %{ path_prefix: "us" }
@@ -33,10 +33,10 @@ config :polygot,
 
 ## Router
 
-You'll need to import `Polygot` to your router(s), it is recommended that you do so in the `def router do` section in `web/web.ex`:
+You'll need to import `Alternate` to your router(s), it is recommended that you do so in the `def router do` section in `web/web.ex`:
 
 ```elixir
-import Polygot
+import Alternate
 ```
 
 this will let you be able to use the `localize` macro in your routes like this:
@@ -49,14 +49,14 @@ if we run `mix phoenix.routes` we'll see that it created all the routes for our 
 
 ```bash
 $ mix phoenix.routes
-page_path  GET  /gb  PolygotExample.PageController [action: :index, locale: "en-GB"]
-page_path  GET  /us  PolygotExample.PageController [action: :index, locale: "en-US"]
+page_path  GET  /gb  AlternateExample.PageController [action: :index, locale: "en-GB"]
+page_path  GET  /us  AlternateExample.PageController [action: :index, locale: "en-US"]
 ```
 
-Now all that's left to do is to add Polygot's plug into your pipeline, so that it can set the appropiate locale based on the requested path:
+Now all that's left to do is to add Alternate's plug into your pipeline, so that it can set the appropiate locale based on the requested path:
 
 ```elixir
-plug Polygot.Plug
+plug Alternate.Plug
 ```
 
 Now when you load `http://exmple.com/gb` the `:locale` assign will be equal to `"en-GB"`, and your Gettext locale will be set to `"en-GB"` automatically.
@@ -76,7 +76,7 @@ The locales that you don't define in the `translations` map will use the `/start
 We'll need to add an extra `init/1` function in or controllers so that they can support localised actions, you can add this to the `controller` section of your `web/web.ex`.
 
 ```elixir
-use Polygot.Controller
+use Alternate.Controller
 ```
 
 ## Route helpers
@@ -84,7 +84,7 @@ use Polygot.Controller
 To generate localized routes we'll need to add this:
 
 ```elixir
-import Polygot.Helpers
+import Alternate.Helpers
 ```
 
 to our `controller` and `view` sections of our `web/web.ex`

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-config :polygot,
+config :alternate,
   locales: %{},
-  locale_assign_key: :polygot_locale,
-  gettext_module: Polygot.Gettext,
+  locale_assign_key: :alternate_locale,
+  gettext_module: Alternate.Gettext,
   gettext_domain: "default"

--- a/lib/alternate.ex
+++ b/lib/alternate.ex
@@ -1,11 +1,11 @@
-defmodule Polygot do
+defmodule Alternate do
 
   @http_methods [
     :get, :post, :put, :patch, :delete, :options, :connect, :trace, :head
   ]
 
-  @locales Application.get_env(:polygot, :locales, %{})
-  @locale_assign_key Application.get_env(:polygot, :locale_assign_key, :polygot_locale)
+  @locales Application.get_env(:alternate, :locales, %{})
+  @locale_assign_key Application.get_env(:alternate, :locale_assign_key, :alternate_locale)
 
   defp do_localize({verb, meta, [ path, plug, plug_opts, options ]}) do
     Enum.map(@locales, fn({locale, config}) ->

--- a/lib/controller.ex
+++ b/lib/controller.ex
@@ -1,4 +1,4 @@
-defmodule Polygot.Controller do
+defmodule Alternate.Controller do
 
   defmacro __using__(_) do
     quote do

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -1,15 +1,15 @@
-defmodule Polygot.Helpers do
+defmodule Alternate.Helpers do
 
-  @locale_assign_key Application.get_env(:polygot, :locale_assign_key, :polygot_locale)
+  @locale_assign_key Application.get_env(:alternate, :locale_assign_key, :alternate_locale)
 
-  def localize_plug_opts(%Plug.Conn{assigns: assigns} = conn, opts) do
+  def localize_plug_opts(%Plug.Conn{assigns: assigns} = _conn, opts) do
     locale = Map.fetch!(assigns, @locale_assign_key)
     [ action: opts, locale: locale ]
   end
 
-  defmacro localize({helper, meta, [ conn, opts | rest ]} = x) do
+  defmacro localize({helper, meta, [ conn, opts | rest ]}) do
     plug_opts = quote do
-      Polygot.Helpers.localize_plug_opts(unquote(conn), unquote(opts))
+      Alternate.Helpers.localize_plug_opts(unquote(conn), unquote(opts))
     end
     {helper, meta, [conn, plug_opts, rest]}
   end

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -1,10 +1,8 @@
-defmodule Polygot.Plug do
+defmodule Alternate.Plug do
 
-  import Plug.Conn
-
-  @locales Application.get_env(:polygot, :locales, %{})
-  @gettext Application.get_env(:polygot, :gettext_module, nil)
-  @locale_assign_key Application.get_env(:polygot, :locale_assign_key, :polygot_locale)
+  @locales Application.get_env(:alternate, :locales, %{})
+  @gettext Application.get_env(:alternate, :gettext_module, nil)
+  @locale_assign_key Application.get_env(:alternate, :locale_assign_key, :alternate_locale)
 
   def init(opts), do: opts
 
@@ -14,7 +12,6 @@ defmodule Polygot.Plug do
         nil ->
           conn
         locale ->
-          IO.inspect locale
           Gettext.put_locale(@gettext, locale)
           conn
       end

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
-defmodule Polygot.Mixfile do
+defmodule Alternate.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :polygot,
+    [app: :alternate,
      version: "0.1.2",
      elixir: "~> 1.3",
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
-     name: "Polygot",
-     docs: [extras: ["README.md"], main: "Polygot"],
+     name: "Alternate",
+     docs: [extras: ["README.md"], main: "Alternate"],
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package,
@@ -32,7 +32,7 @@ defmodule Polygot.Mixfile do
   defp package do
     [ maintainers: ["Mohamed Boudra"],
       licenses: ["Apache License 2.0"],
-      links: %{ "Github" => "https://github.com/boudra/polygot" },
+      links: %{ "Github" => "https://github.com/boudra/alternate" },
       files: ~w(lib priv web README.md mix.exs LICENSE.md)]
   end
 end

--- a/test/polygot_test.exs
+++ b/test/polygot_test.exs
@@ -1,6 +1,6 @@
-defmodule PolygotTest do
+defmodule AlternateTest do
   use ExUnit.Case
-  doctest Polygot
+  doctest Alternate
 
   test "the truth" do
     assert 1 + 1 == 2


### PR DESCRIPTION
Why? Because `polygot` is misspelled and theres already a package with the same name: https://hex.pm/packages/polyglot