### PR TITLE
Fix controller init

### DIFF
--- a/lib/controller.ex
+++ b/lib/controller.ex
@@ -5,6 +5,9 @@ defmodule Alternate.Controller do
       def init([ action: action, locale: _ ]) do
         action
       end
+      def init(opts) do
+        opts
+      end
     end
   end
 


### PR DESCRIPTION
There was an error when I was using non localized routes in other scopes.

I just added the default `init/1` from phoenix as a fallback (https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/controller/pipeline.ex#L18) that, if I understand well, was overridden (https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/controller/pipeline.ex#L37)