### PR TITLE
Add new Plug features and new route helpers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,5 +3,6 @@ use Mix.Config
 config :alternate,
   locales: %{},
   locale_assign_key: :alternate_locale,
+  session_assign_key: nil,
   gettext_module: Alternate.Gettext,
   gettext_domain: "default"

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,7 @@ use Mix.Config
 config :alternate,
   locales: %{},
   locale_assign_key: :alternate_locale,
+  default_fallback_locale: "default",
   session_assign_key: nil,
   gettext_module: Alternate.Gettext,
   gettext_domain: "default"

--- a/lib/alternate.ex
+++ b/lib/alternate.ex
@@ -19,10 +19,21 @@ defmodule Alternate do
     Application.get_env(:alternate, :locale_assign_key, :alternate_locale)
   end
 
+  defp build_options(options, locale) do
+    quote do
+      assigns_with_locale = Map.new([{unquote(locale_assign_key), unquote(locale)}])
+
+      assigns =
+        Keyword.get(unquote(options), :assigns, %{})
+        |> Map.merge(assigns_with_locale)
+
+      Keyword.put(unquote(options), :assigns, assigns)
+    end
+  end
+
   defp do_localize({verb, meta, [path, plug, plug_opts, options]}) do
     locales
     |> Enum.to_list()
-    |> Enum.concat([{nil, %{path_prefix: ""}}])
     |> Enum.map(fn {locale, config} ->
       path =
         quote do
@@ -37,19 +48,13 @@ defmodule Alternate do
           end <> translated_path
         end
 
-      options =
-        quote do
-          assigns_with_locale = Map.new([{unquote(locale_assign_key), unquote(locale)}])
+      options = build_options(options, locale)
 
-          assigns =
-            Keyword.get(unquote(options), :assigns, %{})
-            |> Map.merge(assigns_with_locale)
-
-          Keyword.put(unquote(options), :assigns, assigns)
-        end
-
-      {verb, meta, [path, plug, [action: plug_opts, locale: locale], options]}
+      {verb, meta, [path, plug, [action: plug_opts, locale: locale], build_options(options, nil)]}
     end)
+    |> Enum.concat([
+      {verb, meta, [path, plug, plug_opts, build_options(options, nil)]}
+    ])
   end
 
   defmacro localize({verb, meta, [path, plug, plug_opts]}) when verb in @http_methods do

--- a/lib/alternate.ex
+++ b/lib/alternate.ex
@@ -21,7 +21,7 @@ defmodule Alternate do
 
   defp build_options(options, locale) do
     quote do
-      assigns_with_locale = Map.new([{unquote(locale_assign_key), unquote(locale)}])
+      assigns_with_locale = Map.new([{unquote(locale_assign_key()), unquote(locale)}])
 
       assigns =
         Keyword.get(unquote(options), :assigns, %{})
@@ -32,7 +32,7 @@ defmodule Alternate do
   end
 
   defp do_localize({verb, meta, [path, plug, plug_opts, options]}) do
-    locales
+    locales()
     |> Enum.to_list()
     |> Enum.map(fn {locale, config} ->
       path =

--- a/lib/alternate.ex
+++ b/lib/alternate.ex
@@ -50,7 +50,8 @@ defmodule Alternate do
 
       options = build_options(options, locale)
 
-      {verb, meta, [path, plug, [action: plug_opts, locale: locale], build_options(options, nil)]}
+      {verb, meta,
+       [path, plug, [action: plug_opts, locale: locale], build_options(options, locale)]}
     end)
     |> Enum.concat([
       {verb, meta, [path, plug, plug_opts, build_options(options, nil)]}

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -10,4 +10,8 @@ defmodule Alternate.Config do
   def gettext() do
     Application.get_env(:alternate, :gettext_module, nil)
   end
+
+  def default_fallback_locale() do
+    Application.get_env(:alternate, :default_fallback_locale, nil)
+  end
 end

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -4,7 +4,7 @@ defmodule Alternate.Config do
   end
 
   def locale_session_key() do
-    Application.get_env(:alternate, :locale_session_key, "alternate_locale")
+    Application.get_env(:alternate, :locale_session_key, nil)
   end
 
   def gettext() do

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -1,0 +1,13 @@
+defmodule Alternate.Config do
+  def locale_assign_key() do
+    Application.get_env(:alternate, :locale_assign_key, :alternate_locale)
+  end
+
+  def locale_session_key() do
+    Application.get_env(:alternate, :locale_session_key, "alternate_locale")
+  end
+
+  def gettext() do
+    Application.get_env(:alternate, :gettext_module, nil)
+  end
+end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -38,9 +38,17 @@ defmodule Alternate.Helpers do
       path_params
       |> Enum.reduce(conn.path_info, fn {k, v}, path ->
         Enum.map(path, fn
-          ^v -> ":#{k}"
-          v -> v
+          ^v ->
+            ":#{k}"
+
+          route_element ->
+            if is_list(v) and route_element in v do
+              "*#{k}"
+            else
+              route_element
+            end
         end)
+        |> Enum.uniq()
       end)
 
     query_params = Enum.to_list(conn.query_params)

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -42,6 +42,8 @@ defmodule Alternate.Helpers do
             ":#{k}"
 
           route_element ->
+            route_element = URI.decode_www_form(route_element)
+
             if is_list(v) and route_element in v do
               "*#{k}"
             else

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -47,6 +47,14 @@ defmodule Alternate.Helpers do
     alternate_current_route(conn, "url", locale)
   end
 
+  def alternate_path(conn, locale, controller, action, params) do
+    alternate_route(conn, "path", locale, controller, action, params)
+  end
+
+  def alternate_url(conn, locale, controller, action, params) do
+    alternate_route(conn, "url", locale, controller, action, params)
+  end
+
   def localize_plug_opts(%Plug.Conn{assigns: assigns} = _conn, opts) do
     locale = Map.fetch!(assigns, Config.locale_assign_key())
     [action: opts, locale: locale]

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -112,8 +112,16 @@ defmodule Alternate.Helpers do
   end
 
   def localize_plug_opts(%Plug.Conn{assigns: assigns} = _conn, opts) do
-    locale = Map.fetch!(assigns, Config.locale_assign_key())
-    [action: opts, locale: locale]
+    case Map.fetch(assigns, Config.locale_assign_key()) do
+      {:ok, nil} ->
+        opts
+
+      {:ok, locale} ->
+        [action: opts, locale: locale]
+
+      :error ->
+        opts
+    end
   end
 
   defmacro localize({helper, meta, [conn, opts | rest]}) do

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -28,9 +28,7 @@ defmodule Alternate.Helpers do
   end
 
   def alternate_current_route(conn, type, locale) do
-    router =
-      conn
-      |> Phoenix.Controller.router_module()
+    router = Phoenix.Controller.router_module(conn)
 
     path_params = conn.path_params
 
@@ -45,17 +43,13 @@ defmodule Alternate.Helpers do
         end)
       end)
 
-    query_params =
-      conn.query_params
-      |> Enum.to_list()
+    query_params = Enum.to_list(conn.query_params)
 
     route_params =
-      original_path_info
-      |> Enum.reduce([], fn
+      Enum.reduce(original_path_info, [], fn
         ":" <> key, params -> params ++ [Map.get(path_params, key, nil)]
         _segment, params -> params
-      end)
-      |> Enum.concat([query_params] |> Enum.reject(&Enum.empty?(&1)))
+      end) ++ [query_params]
 
     original_path = "/" <> Enum.join(original_path_info, "/")
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -56,6 +56,7 @@ defmodule Alternate.Helpers do
     route_params =
       Enum.reduce(original_path_info, [], fn
         ":" <> key, params -> params ++ [Map.get(path_params, key, nil)]
+        "*" <> key, params -> params ++ [Map.get(path_params, key, nil)]
         _segment, params -> params
       end) ++ [query_params]
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -1,4 +1,6 @@
 defmodule Alternate.Helpers do
+  alias Alternate.Config
+
   def alternate_route(conn, type, locale, controller, action, params) do
     router =
       conn

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -37,7 +37,9 @@ defmodule Alternate.Helpers do
     original_path_info =
       path_params
       |> Enum.reduce(conn.path_info, fn {k, v}, path ->
-        Enum.map(path, fn
+        path
+        |> Enum.map(&URI.decode_www_form/1)
+        |> Enum.map(fn
           ^v ->
             ":#{k}"
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -1,5 +1,37 @@
 defmodule Alternate.Helpers do
-  @locale_assign_key Application.get_env(:alternate, :locale_assign_key, :alternate_locale)
+  @locale_assign_key Config.locale_assign_key()
+
+  def alternate_route(conn, locale) do
+    route_params =
+      conn.params
+      |> Enum.reject(fn {k, _} ->
+        conn.body_params |> Map.keys() |> Enum.member?(k)
+      end)
+      |> Enum.reject(fn {k, _} ->
+        conn.query_params |> Map.keys() |> Enum.member?(k)
+      end)
+      |> Map.new()
+      |> Map.values()
+
+    controller =
+      conn
+      |> Phoenix.Controller.controller_module()
+      |> Phoenix.Naming.resource_name("Controller")
+
+    action =
+      conn
+      |> Phoenix.Controller.action_name()
+
+    router =
+      conn
+      |> Phoenix.Controller.router_module()
+
+    apply(
+      String.to_atom("#{router}.Helpers"),
+      String.to_atom("#{controller}_path"),
+      [conn, [action: action, locale: locale]] ++ route_params
+    )
+  end
 
   def localize_plug_opts(%Plug.Conn{assigns: assigns} = _conn, opts) do
     locale = Map.fetch!(assigns, @locale_assign_key)

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -20,8 +20,15 @@ defmodule Alternate.Plug do
          gettext_module
        )
        when is_atom(gettext_module) do
-    if locale = conn.assigns[assign_key] do
-      Gettext.put_locale(gettext_module, locale)
+    with nil <- conn.assigns[assign_key],
+         fallback_locale when is_nil(fallback_locale) != nil <- Config.default_fallback_locale() do
+      Gettext.put_locale(gettext_module, fallback_locale)
+    else
+      nil ->
+        raise "Define a fallback_locale"
+
+      locale ->
+        Gettext.put_locale(gettext_module, locale)
     end
 
     conn

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -1,28 +1,93 @@
 defmodule Alternate.Plug do
-  def locale_assign_key do
-    Application.get_env(:alternate, :locale_assign_key, :alternate_locale)
+  alias Alternate.{Config, Helpers}
+
+  import Plug.Conn
+
+  def init(%{} = opts) do
+    opts
+    |> Map.put_new(:assign_key, Config.locale_assign_key())
+    |> Map.put_new(:session_key, Config.locale_session_key())
+    |> Map.put_new(:gettext, Config.gettext())
   end
 
-  def gettext do
-    Application.get_env(:alternate, :gettext_module, nil)
+  def init(_) do
+    init(%{})
   end
 
-  def init(opts), do: opts
+  defp put_gettext_locale(
+         conn,
+         assign_key,
+         gettext_module
+       )
+       when is_atom(gettext_module) do
+    if locale = conn.assigns[assign_key] do
+      Gettext.put_locale(gettext_module, locale)
+    end
 
-  def call(%Plug.Conn{assigns: assigns} = conn, _opts) do
-    case gettext do
+    conn
+  end
+
+  defp put_gettext_locale(conn, _, nil) do
+    conn
+  end
+
+  defp put_session_locale(
+         conn,
+         assign_key,
+         session_key
+       )
+       when is_binary(session_key) do
+    case conn.assigns[assign_key] do
       nil ->
         conn
 
-      gettext ->
-        case Map.get(assigns, locale_assign_key, nil) do
-          nil ->
-            conn
-
-          locale ->
-            Gettext.put_locale(gettext, locale)
-            conn
-        end
+      locale ->
+        conn
+        |> put_session(session_key, locale)
     end
+  end
+
+  defp put_session_locale(conn, _, _) do
+    conn
+  end
+
+  defp redirect_to_localized_route(
+         conn,
+         assign_key,
+         session_key
+       )
+       when is_binary(session_key) do
+    case {conn.assigns[assign_key], get_session(conn, session_key)} do
+      {nil, locale} when is_binary(locale) ->
+        conn
+        |> put_resp_header("location", Helpers.alternate_route(conn, locale))
+        |> put_status(302)
+        |> halt()
+
+      _ ->
+        conn
+    end
+  end
+
+  defp redirect_to_localized_route(conn, _, _) do
+    conn
+  end
+
+  def call(%Plug.Conn{assigns: assigns} = conn, %{
+        gettext: gettext_module,
+        assign_key: assign_key,
+        session_key: session_key
+      }) do
+    conn
+    |> assign(assign_key, assigns[assign_key])
+    |> put_gettext_locale(assign_key, gettext_module)
+    |> put_session_locale(assign_key, session_key)
+    |> register_before_send(fn
+      %{status: 200, method: "GET"} ->
+        redirect_to_localized_route(conn, assign_key, session_key)
+
+      _ ->
+        conn
+    end)
   end
 end

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -60,7 +60,7 @@ defmodule Alternate.Plug do
     case {conn.assigns[assign_key], get_session(conn, session_key)} do
       {nil, locale} when is_binary(locale) ->
         conn
-        |> put_resp_header("location", Helpers.alternate_route(conn, locale))
+        |> put_resp_header("location", Helpers.alternate_current_url(conn, locale))
         |> put_status(302)
         |> halt()
 

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -59,10 +59,16 @@ defmodule Alternate.Plug do
        when is_binary(session_key) do
     case {conn.assigns[assign_key], get_session(conn, session_key)} do
       {nil, locale} when is_binary(locale) ->
-        conn
-        |> put_status(302)
-        |> Phoenix.Controller.redirect(external: Helpers.alternate_current_url(conn, locale))
-        |> halt()
+        case Helpers.alternate_current_url(conn, locale) do
+          nil ->
+            conn
+
+          url ->
+            conn
+            |> put_status(302)
+            |> Phoenix.Controller.redirect(external: url)
+            |> halt()
+        end
 
       _ ->
         conn
@@ -83,10 +89,10 @@ defmodule Alternate.Plug do
     |> put_gettext_locale(assign_key, gettext_module)
     |> put_session_locale(assign_key, session_key)
     |> case do
-      %{method: "GET"} ->
+      conn = %{method: "GET"} ->
         redirect_to_localized_route(conn, assign_key, session_key)
 
-      _ ->
+      conn ->
         conn
     end
   end

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -60,8 +60,8 @@ defmodule Alternate.Plug do
     case {conn.assigns[assign_key], get_session(conn, session_key)} do
       {nil, locale} when is_binary(locale) ->
         conn
-        |> put_resp_header("location", Helpers.alternate_current_url(conn, locale))
         |> put_status(302)
+        |> Phoenix.Controller.redirect(external: Helpers.alternate_current_url(conn, locale))
         |> halt()
 
       _ ->
@@ -82,12 +82,12 @@ defmodule Alternate.Plug do
     |> assign(assign_key, assigns[assign_key])
     |> put_gettext_locale(assign_key, gettext_module)
     |> put_session_locale(assign_key, session_key)
-    |> register_before_send(fn
-      %{status: 200, method: "GET"} ->
+    |> case do
+      %{method: "GET"} ->
         redirect_to_localized_route(conn, assign_key, session_key)
 
       _ ->
         conn
-    end)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Alternate.Mixfile do
     [
       app: :alternate,
       version: "0.1.7",
-      elixir: "~> 1.3",
+      elixir: "~> 1.6",
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       name: "Alternate",
       docs: [extras: ["README.md"], main: "Alternate"],
@@ -25,7 +25,7 @@ defmodule Alternate.Mixfile do
 
   defp deps do
     [
-      {:phoenix, "~> 1.1"},
+      {:phoenix, "~> 1.3"},
       {:gettext, "~> 0.9"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Alternate.Mixfile do
   def project do
     [
       app: :alternate,
-      version: "0.1.6",
+      version: "0.1.7",
       elixir: "~> 1.3",
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       name: "Alternate",

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,10 @@
-%{"earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
+%{
+  "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
-  "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
-  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.0", "c31af4be22afeeebfaf246592778c8c840e5a1ddc7ca87610c41ccfb160c2c57", [:mix], []},
-  "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.3.2", "2a00d751f51670ea6bc3f2ba4e6eb27ecb8a2c71e7978d9cd3e5de5ccf7378bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -8,9 +8,9 @@ defmodule AlternatePlugTest do
 
   test "plug sets the Gettext locale" do
     Application.put_env(:alternate, :gettext_module, TestGettext)
-    opts = Alternate.Plug.init(nil)
+    opts = Alternate.Plug.init([])
 
-    build_conn
+    build_conn()
     |> assign(:alternate_locale, "en-US")
     |> Alternate.Plug.call(opts)
 


### PR DESCRIPTION
Now the plug can also:

* Save the locale in the session
* Redirect to the right localized route using the locale saved in the session when a request goes to the unlocalized route
* Add `alternate_current_path`, `alternate_current_url`, `alternate_path` and `alternate_url`  to get routes of other locales.
